### PR TITLE
chore: added support for forFeatureAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,31 @@ import { HttpModule } from "@nodeflip/nest-axios-http";
 export class AppModule {}
 
 ```
+
+### Inject other modules and use it
+
+```typescript
+
+import { Module } from "@nestjs/common";
+import { HttpModule } from "@nodeflip/nest-axios-http";
+
+@Module({
+  imports: [
+    HttpModule.forFeatureAsync({
+      logger: customLogger, // Custom logger instance
+      serviceName: 'MyService', // Service name for logging
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => {
+        return {
+          baseURL: configService.get('API_BASE_URL'),
+          enableLogging: configService.get('ENABLE_LOGGING'),
+        }
+      }
+    }),
+  ],
+})
+
+```
 ## License
 
 This package is [MIT licensed](LICENSE).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nodeflip/nest-axios-http",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "description": "A NestJS module for simplified HTTP requests using Axios with dynamic configuration, logging, and interceptor support.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/test/HttpModule.spec.ts
+++ b/src/test/HttpModule.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
+import { DynamicModule, FactoryProvider, ModuleMetadata } from "@nestjs/common";
 
 import { HttpModule } from "../http/http.module"; // Adjust the import path as necessary
 import { HttpService } from "../http/http.service";
@@ -61,5 +62,24 @@ describe("HttpModule", () => {
 
     expect(serviceOne).toBeInstanceOf(HttpService);
     expect(serviceTwo).toBeInstanceOf(HttpService);
+  });
+
+  it("should handle asynchronous dynamic configuration", async () => {
+    const asyncConfig = {
+      imports: [] as ModuleMetadata["imports"],
+      inject: [] as FactoryProvider["inject"],
+      useFactory: async () => ({
+        config: { baseURL: "http://async-config.com" },
+      }),
+      serviceName: "AsyncService",
+    };
+
+    const asyncModule = HttpModule.forFeatureAsync(asyncConfig);
+    const featureModule = await Test.createTestingModule({
+      imports: [asyncModule],
+    }).compile();
+    const asyncHttpService = featureModule.get<HttpService>("AsyncService");
+
+    expect(asyncHttpService).toBeInstanceOf(HttpService);
   });
 });


### PR DESCRIPTION
### Changelog

Added the support for `forFeatureAsync`

```
@Module({
  imports: [
    HttpModule.forFeatureAsync({
      logger: customLogger, // Custom logger instance
      serviceName: 'MyService', // Service name for logging
      inject: [ConfigService],
      useFactory: (configService: ConfigService) => {
        return {
          baseURL: configService.get('API_BASE_URL'),
          enableLogging: configService.get('ENABLE_LOGGING'),
        }
      }
    }),
  ],
})
```